### PR TITLE
edit recipe dialog bugfix

### DIFF
--- a/meal-planning/src/components/recipe-library/RecipesLibrary.js
+++ b/meal-planning/src/components/recipe-library/RecipesLibrary.js
@@ -39,7 +39,7 @@ const RecipesLibrary = () => {
       recipe => recipe.id === editedRecipe.id
     );
 
-    if (originalRecipeIndex) {
+    if (originalRecipeIndex > 0) {
       const newRecipes = [...recipes];
       newRecipes.splice(originalRecipeIndex, 1, editedRecipe);
       setRecipes(newRecipes);

--- a/meal-planning/src/components/recipe-library/RecipesLibrary.js
+++ b/meal-planning/src/components/recipe-library/RecipesLibrary.js
@@ -39,7 +39,7 @@ const RecipesLibrary = () => {
       recipe => recipe.id === editedRecipe.id
     );
 
-    if (originalRecipeIndex > 0) {
+    if (originalRecipeIndex > -1) {
       const newRecipes = [...recipes];
       newRecipes.splice(originalRecipeIndex, 1, editedRecipe);
       setRecipes(newRecipes);


### PR DESCRIPTION
Have to add the " > -1 " because an array index of 0 is perfectly valid. In the case of a truthiness check though, it's falsy. This is why editing the **first** recipe threw an error.